### PR TITLE
refactor/filter out tool itself

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var Version = "v1.0.7"
+var Version = "v1.0.8"
 
 func main() {
 	app := &cli.App{

--- a/sysinformer/cpu.go
+++ b/sysinformer/cpu.go
@@ -106,13 +106,21 @@ func getCPUInfo() (map[string]interface{}, error) {
 			})
 		}
 
+		// Filter out 'sysinformer' or 'sysinfo' process
+		var filteredProcs []procInfo
+		for _, proc := range procs {
+			if proc.name != "sysinformer" && proc.name != "sysinfo" {
+				filteredProcs = append(filteredProcs, proc)
+			}
+		}
+
 		// Sort by CPU usage
-		sort.Slice(procs, func(i, j int) bool {
-			return procs[i].cpuPercent > procs[j].cpuPercent
+		sort.Slice(filteredProcs, func(i, j int) bool {
+			return filteredProcs[i].cpuPercent > filteredProcs[j].cpuPercent
 		})
 
-		// Get top 5 processes
-		top5 := procs
+		// Get top 5 processes (excluding sysinformer)
+		top5 := filteredProcs
 		if len(top5) > 5 {
 			top5 = top5[:5]
 		}

--- a/sysinformer/memory.go
+++ b/sysinformer/memory.go
@@ -133,14 +133,22 @@ func getMemoryInfo() (map[string]interface{}, error) {
 			})
 		}
 
+		// Filter out 'sysinformer' or 'sysinfo' process
+		var filteredProcs []procInfo
+		for _, proc := range procs {
+			if proc.name != "sysinformer" && proc.name != "sysinfo" {
+				filteredProcs = append(filteredProcs, proc)
+			}
+		}
+
 		// Sort by memory usage
-		sort.Slice(procs, func(i, j int) bool {
-			return procs[i].memoryPercent > procs[j].memoryPercent
+		sort.Slice(filteredProcs, func(i, j int) bool {
+			return filteredProcs[i].memoryPercent > filteredProcs[j].memoryPercent
 		})
 
-		// Get top 5 processes
-		if len(procs) > 5 {
-			procs = procs[:5]
+		// Get top 5 processes (excluding sysinformer)
+		if len(filteredProcs) > 5 {
+			filteredProcs = filteredProcs[:5]
 		}
 
 		return map[string]interface{}{
@@ -153,7 +161,7 @@ func getMemoryInfo() (map[string]interface{}, error) {
 			"swap_usage":              swapMemory.UsedPercent,
 			"swap_used_percentage_calc": swapUsedPercentageCalc,
 			"warning":                  warning,
-			"top_processes":            procs,
+			"top_processes":            filteredProcs,
 		}, nil
 	}
 


### PR DESCRIPTION
- **refactor(cpu,memory): exclude sysinformer from top process output**
- **fix: Update version to v1.0.8**
